### PR TITLE
Patching Operator Mono produced the following errors due to attemptin…

### DIFF
--- a/scripts/powerline-fontpatcher
+++ b/scripts/powerline-fontpatcher
@@ -114,8 +114,10 @@ def patch_one_font(source_font, target_font, rename_font=True):
 
 	# FIXME: Menlo and Meslo font do have these substitutes, but U+FB01 and
 	#        U+FB02 still do not show up for fi and fl.
-	target_font[0xFB01].removePosSub('*')  # fi ligature
-	target_font[0xFB02].removePosSub('*')  # fl ligature
+	if 0xFB01 in target_font:
+		target_font[0xFB01].removePosSub('*')  # fi ligature
+	if 0xFB02 in target_font:
+		target_font[0xFB02].removePosSub('*')  # fl ligature
 
 	# Generate patched font
 	extension = os.path.splitext(target_font.path)[1]


### PR DESCRIPTION
…g to remove missing glyphs:

Traceback (most recent call last):
  File "./powerline-fontpatcher", line 144, in <module>
    raise SystemExit(main(sys.argv[1:]))
  File "./powerline-fontpatcher", line 141, in main
    return patch_fonts(args.source_font, args.target_fonts, args.rename_font)
  File "./powerline-fontpatcher", line 133, in patch_fonts
    patch_one_font(source_font, target_font, rename_font)
  File "./powerline-fontpatcher", line 117, in patch_one_font
    target_font[0xFB01].removePosSub('*')  # fi ligature
TypeError: No such glyph

This commit first checks for the existence of glyphs 0xFB01 and 0xFB02 before attempting to remove them.